### PR TITLE
Add "regexCheck" for Facebook and Flipboard

### DIFF
--- a/data.json
+++ b/data.json
@@ -15,7 +15,7 @@
     "url": "https://www.facebook.com/{}",
     "urlMain": "https://www.facebook.com/",
     "errorType": "status_code",
-    "regexCheck": "^([a-zA-Z0-9.]){5,}$"
+    "regexCheck": "^a-zA-Z0-9{4,49}(?<!.com|.org|.net)$"
   },
   "YouTube": {
     "url": "https://www.youtube.com/{}",

--- a/data.json
+++ b/data.json
@@ -14,7 +14,8 @@
   "Facebook": {
     "url": "https://www.facebook.com/{}",
     "urlMain": "https://www.facebook.com/",
-    "errorType": "status_code"
+    "errorType": "status_code",
+    "regexCheck": "^([a-zA-Z0-9.]){5,}$"
   },
   "YouTube": {
     "url": "https://www.youtube.com/{}",
@@ -108,7 +109,8 @@
     "url": "https://flipboard.com/@{}",
     "urlMain": "https://flipboard.com/",
     "errorType": "message",
-    "errorMsg": "loading"
+    "errorMsg": "loading",
+    "regexCheck": "^([a-zA-Z0-9_]){1,15}$"
   },
   "SlideShare": {
     "url": "https://slideshare.net/{}",


### PR DESCRIPTION
Facebook from: https://www.facebook.com/help/409473442437047 but I don't know how to handle this requirement: "They can't contain generic terms or extensions (.com, .net)".
Flipboard from: https://flipboard.helpshift.com/a/flipboard/?s=managing-your-account&f=help-with-username-issues&p=web