### PR TITLE
Fix case sensitivity bug

### DIFF
--- a/data.json
+++ b/data.json
@@ -560,5 +560,11 @@
     "urlMain": "https://coderwall.com/",
     "errorType": "message",
     "errorMsg": "404! Our feels when that url is used"
+  },
+  "Wikipedia": {
+    "url": "https://www.wikipedia.org/wiki/User:{}",
+    "urlMain": "https://www.wikipedia.org/",
+    "errorType": "message",
+    "errorMsg": "If a page was recently created here, it may not be visible yet because of a delay in updating the database"
   }
 }

--- a/sherlock.py
+++ b/sherlock.py
@@ -80,7 +80,7 @@ def sherlock(username, verbose=False, tor=False, unique_tor=False):
                        there was an HTTP error when checking for existence.
     """
     global amount
-    fname = username + ".txt"
+    fname = username.lower() + ".txt"
 
     if os.path.isfile(fname):
         os.remove(fname)


### PR DESCRIPTION
"os.path.isfile(fname)" is case-insensitive while "os.remove(fname)" is case sensitive, this means that if you search a username, and then search it again with a different case, there will be a FileNotFoundError.