### PR TITLE
Remove useless end of <a> anchor in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 
 <p align="center">
 <img src="./screenshot/preview.png">
-</a>
 </p>
 
 ## Installation


### PR DESCRIPTION
Their was an </a> in README.md but no starting <a> anchor.