### PR TITLE
Response time metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ optional arguments:
   -h, --help            show this help message and exit
   --version             Display version information and dependencies.
   --verbose, -v, -d, --debug
-                        Display extra debugging information.
+                        Display extra debugging information and metrics.
   --quiet, -q           Disable debugging information (Default Option).
   --tor, -t             Make requests over TOR; increases runtime; requires
                         TOR to be installed and in system path.

--- a/sherlock.py
+++ b/sherlock.py
@@ -29,9 +29,12 @@ amount=0
 # TODO: fix tumblr
 
 
-# Extends FutureSession to add response time metric
-# This is taken (almost) directly from here: https://github.com/ross/requests-futures#working-in-the-background
 class ElapsedFuturesSession(FuturesSession):
+    """
+    Extends FutureSession to add a response time metric to each request.
+
+    This is taken (almost) directly from here: https://github.com/ross/requests-futures#working-in-the-background
+    """
 
     def request(self, method, url, hooks={}, *args, **kwargs):
         start = time()
@@ -72,7 +75,7 @@ def print_error(err, errstr, var, verbose=False):
           Fore.YELLOW + f" {err if verbose else var}")
 
 
-def create_response_time(response_time, verbose):
+def format_response_time(response_time, verbose):
     return " [{} ms]".format(response_time) if verbose else ""
 
 
@@ -80,7 +83,7 @@ def print_found(social_network, url, response_time, verbose=False):
     print((Style.BRIGHT + Fore.WHITE + "[" +
            Fore.GREEN + "+" +
            Fore.WHITE + "]" +
-           create_response_time(response_time, verbose) +
+           format_response_time(response_time, verbose) +
            Fore.GREEN + " {}:").format(social_network), url)
 
 
@@ -88,7 +91,7 @@ def print_not_found(social_network, response_time, verbose=False):
     print((Style.BRIGHT + Fore.WHITE + "[" +
            Fore.RED + "-" +
            Fore.WHITE + "]" +
-           create_response_time(response_time, verbose) +
+           format_response_time(response_time, verbose) +
            Fore.GREEN + " {}:" +
            Fore.YELLOW + " Not Found!").format(social_network))
 
@@ -336,7 +339,7 @@ def main():
                        )
     parser.add_argument("--verbose", "-v", "-d", "--debug",
                         action="store_true",  dest="verbose", default=False,
-                        help="Display extra debugging information."
+                        help="Display extra debugging information and metrics."
                        )
     parser.add_argument("--quiet", "-q",
                         action="store_false", dest="verbose",


### PR DESCRIPTION
Fixes #82 

## Overview

- Exposes metrics about each request's response time (in milliseconds)
- In verbose mode, prints out response times to console

### Understanding the Metrics

Please note that long "response times" are not entirely the fault of the websites we make requests to. These response times are **highly influenced** by a variety of factors on your computer, such as Context Switching. All requests run in separate threads, but access to the network card for I/O is blocked to one request at a time. Therefore, some responses might be "done" earlier than your CPU can process them.

This needs to be tested and understood further (I plan on doing that later). So this PR only exposes these metrics, but doesn't take any actions on them or imply that long response times correlated to the website.

## Implementation Details

I was able to make use of [requests-futures' built-in hooks API](https://github.com/ross/requests-futures#working-in-the-background) to compute the response times. This allows each background thread to compute its own response time, so the main thread doesn't have to schedule time for that. Therefore, this introduces very little overhead!

### Specific changes

- Created `ElapsedFuturesSession` that records start, end, and elapsed time for each request in the background thread
- Abstracted printing success/error to a function, making it more modular

## Testing Done

- Ensured this feature introduces minimal overhead by timing total running time of Sherlock. Did not notice any visible differences.
- Ensured response times are printed in `verbose` mode
- Ensured response times are NOT printed in `quiet` mode
- Ensured response times are always exported to the CSV (in `csv` mode)

## User Experience

With this PR, the following is displayed to the user in `verbose` mode. Note the inclusion of the response times in the second brackets per line.

![addition of response times to console output](https://user-images.githubusercontent.com/11142171/50782295-a037dd00-1275-11e9-8dc0-d2284dafaca0.png)

## Future Work

All response times are stored in the `results_total` and `results_site` dictionaries (in both `quiet` and `verbose` modes). This stored information can be post-processed to output metrics, such as:

- Sites which took the longest to response
- min, max, p50, p90, p99 response times
- Expected timeouts for responses
 
I will create issues for this features when needed.