### PR TITLE
Fixed #99: VirusTotal false positive.

### DIFF
--- a/data.json
+++ b/data.json
@@ -605,7 +605,7 @@
     "url": "https://www.virustotal.com/ui/users/{}/trusted_users",
     "urlMain": "https://www.virustotal.com/",
     "errorType": "message",
-    "errorMsg": "error"
+    "errorMsg": "not found"
   },
   "WebNode": {
     "url": "https://{}.webnode.cz/",

--- a/data.json
+++ b/data.json
@@ -602,9 +602,10 @@
     "errorMsg": "410"
   },
   "VirusTotal": {
-    "url": "https://www.virustotal.com/#/user/{}",
+    "url": "https://www.virustotal.com/ui/users/{}/trusted_users",
     "urlMain": "https://www.virustotal.com/",
-    "errorType": "status_code"
+    "errorType": "message",
+    "errorMsg": "error"
   },
   "WebNode": {
     "url": "https://{}.webnode.cz/",


### PR DESCRIPTION
The main problem with VirusTotal false positives was redirection, so the response code was not handled correctly. My solution fixes this, but the main problem now is that the URL of the user account is actually an API request with a JSON response. It consists of the URL of the home page of the user account, so I do not know whether it is a real problem to find out.

A JSON response if the user exists:
```
{
    "data": [],
    "links": {
        "self": "https://www.virustotal.com/ui/users/root/trusted_users?limit=10"
    }
}
```

A JSON response if the user doesn't exist:
```
{
    "error": {
        "code": "NotFoundError",
        "message": "User \"tdh8316\" not found"
    }
}
```

HEAD requests to this url permitted, thus it parses `error` from small JSON response page.