### PR TITLE
Proposal for a module which loads proxies from a file and checks them if needed.

### DIFF
--- a/load_proxies.py
+++ b/load_proxies.py
@@ -20,3 +20,26 @@ def load_proxies_from_csv(path_to_list):
         proxies = [Proxy(line['ip'],line['port'],line['protocol']) for line in csv_reader]
 
     return proxies
+
+
+"""
+A function which test the proxy by attempting 
+to make a request to the designated website.
+
+We use 'wikipedia.org' as a test, since we can test the proxy anonymity 
+by check if the returning 'X-Client-IP' header matches the proxy ip.
+"""
+
+
+def check_proxy(proxy_ip, proxy_port, protocol):
+    full_proxy = f'{protocol}://{proxy_ip}:{proxy_port}'
+    proxies = {'http': full_proxy, 'https': full_proxy}
+    try:
+        r = requests.get('https://www.wikipedia.org',proxies=proxies, timeout=4)
+        return_proxy = r.headers['X-Client-IP']
+        if proxy_ip==return_proxy:
+            return True
+        else:
+            return False
+    except Exception:
+        return False

--- a/load_proxies.py
+++ b/load_proxies.py
@@ -1,0 +1,22 @@
+import csv
+import requests
+import time
+from collections import namedtuple
+
+"""
+A function which loads proxies from a .csv file, to a list.
+
+Inputs: path to .csv file which contains proxies, described by fields: 'ip', 'port', 'protocol'.
+
+Outputs: list containing proxies stored in named tuples.
+"""
+
+
+def load_proxies_from_csv(path_to_list):
+    Proxy = namedtuple('Proxy', ['ip', 'port', 'protocol'])
+
+    with open(path_to_list, 'r') as csv_file:
+        csv_reader = csv.DictReader(csv_file)
+        proxies = [Proxy(line['ip'],line['port'],line['protocol']) for line in csv_reader]
+
+    return proxies

--- a/load_proxies.py
+++ b/load_proxies.py
@@ -2,6 +2,7 @@ import csv
 import requests
 import time
 from collections import namedtuple
+from colorama import Fore, Style
 
 """
 A function which loads proxies from a .csv file, to a list.
@@ -43,3 +44,53 @@ def check_proxy(proxy_ip, proxy_port, protocol):
             return False
     except Exception:
         return False
+
+
+"""
+A function which takes in one mandatory argument -> a proxy list in
+the format returned by the function 'load_proxies_from_csv'.
+    
+It also takes an optional argument 'max_proxies', if the user wishes to
+cap the number of validated proxies.
+
+Each proxy is tested by the check_proxy function. Since each test is done on 
+'wikipedia.org', in order to be considerate to Wikipedia servers, we are not using any async modules, 
+but are sending successive requests each separated by at least 1 sec.
+
+Outputs: list containing proxies stored in named tuples. 
+"""
+
+
+from colorama import Fore, Style
+
+def check_proxy_list(proxy_list, max_proxies=None):
+    print((Style.BRIGHT + Fore.GREEN + "[" +
+           Fore.YELLOW + "*" +
+           Fore.GREEN + "] Started checking proxies."))
+    working_proxies = []
+
+    # If the user has limited the number of proxies we need,
+    # the function will stop when the working_proxies
+    # loads the max number of requested proxies.
+    if max_proxies != None:
+        for proxy in proxy_list:
+            if len(working_proxies) < max_proxies:
+                time.sleep(1)
+                if check_proxy(proxy.ip,proxy.port,proxy.protocol) == True:
+                    working_proxies.append(proxy)
+            else:
+                break
+    else:
+        for proxy in proxy_list:
+            time.sleep(1)
+            if check_proxy(proxy.ip,proxy.port,proxy.protocol) == True:
+                working_proxies.append(proxy)
+
+    if len(working_proxies) > 0:
+        print((Style.BRIGHT + Fore.GREEN + "[" +
+               Fore.YELLOW + "*" +
+               Fore.GREEN + "] Finished checking proxies."))
+        return working_proxies
+
+    else:
+        raise Exception("Found no working proxies.")

--- a/sherlock.py
+++ b/sherlock.py
@@ -21,6 +21,7 @@ from concurrent.futures import ThreadPoolExecutor
 from colorama import Fore, Style, init
 from requests_futures.sessions import FuturesSession
 from torrequest import TorRequest
+from load_proxies import load_proxies_from_csv, check_proxy_list
 
 module_name = "Sherlock: Find Usernames Across Social Networks"
 __version__ = "0.2.7"

--- a/sherlock.py
+++ b/sherlock.py
@@ -442,9 +442,9 @@ def main():
     if args.proxy_list != None:
         print((Style.BRIGHT + Fore.GREEN + "[" +
                Fore.YELLOW + "*" +
-               Fore.GREEN + "] Checking username" +
+               Fore.GREEN + "] Loading proxies from" +
                Fore.WHITE + " {}" +
-               Fore.GREEN + " on:").format(args.proxy_list))
+               Fore.GREEN + " :").format(args.proxy_list))
 
         proxy_list = load_proxies_from_csv(args.proxy_list)
 

--- a/sherlock.py
+++ b/sherlock.py
@@ -419,6 +419,18 @@ def main():
     # Make prompts
     if args.proxy != None:
         print("Using the proxy: " + args.proxy)
+
+    global proxy_list
+
+    if args.proxy_list != None:
+        print((Style.BRIGHT + Fore.GREEN + "[" +
+               Fore.YELLOW + "*" +
+               Fore.GREEN + "] Checking username" +
+               Fore.WHITE + " {}" +
+               Fore.GREEN + " on:").format(args.proxy_list))
+
+        proxy_list = load_proxies_from_csv(args.proxy_list)
+
     if args.tor or args.unique_tor:
         print("Using TOR to make requests")
         print("Warning: some websites might refuse connecting over TOR, so note that using this option might increase connection errors.")

--- a/sherlock.py
+++ b/sherlock.py
@@ -479,6 +479,15 @@ def main():
     # Run report on all specified users.
     for username in args.username:
         print()
+
+        # We try to ad a random member of the 'proxy_list' var as the proxy of the request.
+        # If we can't access the list or it is empty, we proceed with args.proxy as the proxy.
+        try:
+            random_proxy = random.choice(proxy_list)
+            proxy = f'{random_proxy.protocol}://{random_proxy.ip}:{random_proxy.port}'
+        except (NameError, IndexError):
+            proxy = args.proxy
+
         results = {}
         results = sherlock(username, site_data, verbose=args.verbose,
                            tor=args.tor, unique_tor=args.unique_tor, proxy=args.proxy)

--- a/sherlock.py
+++ b/sherlock.py
@@ -28,6 +28,9 @@ amount = 0
 
 # TODO: fix tumblr
 
+global proxy_list
+
+proxy_list = []
 
 class ElapsedFuturesSession(FuturesSession):
     """

--- a/sherlock.py
+++ b/sherlock.py
@@ -406,7 +406,7 @@ def main():
 
     # Argument check
     # TODO regex check on args.proxy
-    if args.tor and args.proxy != None:
+    if args.tor and (args.proxy != None or args.proxy_list != None):
         raise Exception("TOR and Proxy cannot be set in the meantime.")
 
     # Make prompts

--- a/sherlock.py
+++ b/sherlock.py
@@ -431,6 +431,19 @@ def main():
 
         proxy_list = load_proxies_from_csv(args.proxy_list)
 
+    # Checking if proxies should be checked for anonymity.
+    if args.check_prox != None and args.proxy_list != None:
+        try:
+            limit = int(args.check_prox)
+            if limit == 0:
+                proxy_list = check_proxy_list(proxy_list)
+            elif limit > 0:
+                proxy_list = check_proxy_list(proxy_list, limit)
+            else:
+                raise ValueError
+        except ValueError:
+            raise Exception("Prameter --check_proxies/-cp must be a positive intiger.")
+
     if args.tor or args.unique_tor:
         print("Using TOR to make requests")
         print("Warning: some websites might refuse connecting over TOR, so note that using this option might increase connection errors.")

--- a/sherlock.py
+++ b/sherlock.py
@@ -374,6 +374,16 @@ def main():
                         action="store", dest="proxy", default=None,
                         help="Make requests over a proxy. e.g. socks5://127.0.0.1:1080"
                         )
+    parser.add_argument("--proxy_list", "-pl", metavar='PROXY_LIST',
+                        action="store", dest="proxy_list", default=None,
+                        help="Make requests over a proxy randomly chosen from a list generated from a .csv file."
+                        )
+    parser.add_argument("--check_proxies", "-cp", metavar='CHECK_PROXY',
+                        action="store", dest="check_prox", default=None,
+                        help="To be used with the '--proxy_list' parameter. "
+                             "The script will check if the proxies supplied in the .csv file are working and anonymous."
+                             "Put 0 for no limit on successfully checked proxies, or another number to institute a limit."
+                        )
     parser.add_argument("username",
                         nargs='+', metavar='USERNAMES',
                         action="store",

--- a/sherlock.py
+++ b/sherlock.py
@@ -257,7 +257,8 @@ def sherlock(username, site_data, verbose=False, tor=False, unique_tor=False, pr
         r, error_type, response_time = get_response(request_future=future,
                                                     error_type=error_type,
                                                     social_network=social_network,
-                                                    verbose=verbose)
+                                                    verbose=verbose,
+                                                    retry_no=3)
 
         # Attempt to get request information
         try:

--- a/sherlock.py
+++ b/sherlock.py
@@ -409,6 +409,13 @@ def main():
     if args.tor and (args.proxy != None or args.proxy_list != None):
         raise Exception("TOR and Proxy cannot be set in the meantime.")
 
+    # Proxy argument check.
+    # Does not necessarily need to throw an error,
+    # since we could join the single proxy with the ones generated from the .csv,
+    # but it seems unnecessarily complex at this time.
+    if args.proxy != None and args.proxy_list != None:
+        raise Exception("A single proxy cannot be used along with proxy list.")
+
     # Make prompts
     if args.proxy != None:
         print("Using the proxy: " + args.proxy)


### PR DESCRIPTION
New module load_proxies. It is meant to provide users with the option to use multiple proxies in sherlock just by passing the path to file which stores them. Currently, it only reads form .csv files.

The new module also provides a function which checks anonymity of the loaded proxies (a bit hacky, but works).

Certain changes have been made to sherlock.py to accomodate use of the new module.

Argument '--proxy_list/-pl' should be followed by path to csv file.

Argument '--check_proxies/-cp' can be used only with the -pl argument, and should be set to a max number of working proxies the user wishes to load from csv, and use in sherlock.

Hope you like it, looking forward to comments.