### PR TITLE
Explicitly Close Result Text File

### DIFF
--- a/sherlock.py
+++ b/sherlock.py
@@ -326,6 +326,7 @@ def sherlock(username, site_data, verbose=False, tor=False, unique_tor=False, pr
            Fore.WHITE + "{}").format(fname))
 
     final_score(amount, f)
+    f.close()
     return results_total
 
 


### PR DESCRIPTION
While running tests, I was getting a ResourceWarning about an unclosed file. The result file was not being closed, so it was a valid warning.  Close the file to avoid this warning.