### PR TITLE
Response URL Site Detection Strategy Overhaul

### DIFF
--- a/data.json
+++ b/data.json
@@ -41,7 +41,7 @@
     "errorMsg":"page not found"
   },
   "Pinterest": {
-    "url": "https://www.pinterest.com/{}",
+    "url": "https://www.pinterest.com/{}/",
     "urlMain": "https://www.pinterest.com/",
     "errorType": "response_url",
     "errorUrl": "https://www.pinterest.com/?show_error=true"
@@ -415,7 +415,7 @@
     "errorType": "status_code"
   },
   "WordPress": {
-    "url": "https://{}.wordpress.com",
+    "url": "https://{}.wordpress.com/",
     "urlMain": "https://wordpress.com",
     "errorType": "response_url",
     "errorUrl": "wordpress.com/typo/?subdomain=",

--- a/tests/all.py
+++ b/tests/all.py
@@ -23,7 +23,7 @@ class SherlockDetectTests(SherlockBaseTest):
         """
 
         self.username_check(['jack'],  ['Twitter'],   exist_check=True)
-        #self.username_check(['dfox'],  ['devRant'],   exist_check=True)
+        self.username_check(['dfox'],  ['devRant'],   exist_check=True)
         self.username_check(['blue'],  ['Pinterest'], exist_check=True)
         self.username_check(['kevin'], ['Instagram'], exist_check=True)
         self.username_check(['zuck'],  ['Facebook'],  exist_check=True)
@@ -89,6 +89,54 @@ class SherlockDetectTests(SherlockBaseTest):
         self.username_check(['jackkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk'],
                             ['Pinterest'],
                             exist_check=False
+                           )
+
+        return
+
+
+class SherlockSiteCoverageTests(SherlockBaseTest):
+    def test_coverage_false_via_response_url(self):
+        """Test Username Does Not Exist Site Coverage (Via Response URL).
+
+        This test checks all sites with the "response URL" detection mechanism
+        to ensure that a Username that does not exist is reported that way.
+
+        Keyword Arguments:
+        self                   -- This object.
+
+        Return Value:
+        N/A.
+        Will trigger an assert if detection mechanism did not work as expected.
+        """
+
+        self.username_check(['noonewouldeverusethis7'],
+                            ["Pinterest", "iMGSRC.RU", "Pastebin",
+                             "WordPress", "devRant", "ImageShack", "MeetMe"
+                            ],
+                            exist_check=False
+                           )
+
+        return
+
+    def test_coverage_true_via_response_url(self):
+        """Test Username Does Exist Site Coverage (Via Response URL).
+
+        This test checks all sites with the "response URL" detection mechanism
+        to ensure that a Username that does exist is reported that way.
+
+        Keyword Arguments:
+        self                   -- This object.
+
+        Return Value:
+        N/A.
+        Will trigger an assert if detection mechanism did not work as expected.
+        """
+
+        self.username_check(['blue'],
+                            ["Pinterest", "iMGSRC.RU", "Pastebin",
+                             "WordPress", "devRant", "ImageShack", "MeetMe"
+                            ],
+                            exist_check=True
                            )
 
         return


### PR DESCRIPTION
This is to resolve #128. Note that all of the sites effected by this bug are devRant/iMGSRC.RU/ImageShack/MeetMe.  The other sites using the Response URL detection strategy worked before.

Previously, there was a problem with sites that redirect an attempt to view a non-existing username to the main site. For example, if you try to go to https://devrant.com/users/dfoxxxxxxxxx (a user name that does not exist), then we get a redirect to the https://devrant.com/ root of the site. But, the "response_url" checking algorithm was only looking for the configured error URL being included in the response.  So, these sites always indicated that the username was not found.

Update the "response_url" detection method so that the request does not allow redirects. If we get a 200 response of some type, then the username has been found. However, if we get something like a 302, then we know that the username was not found as we are being redirected.

This whole method seems fragile, but I did exhaustively test all of the supported sites, and they all work.  So, this change is clearly an improvement.