### PR TITLE
Fix EyeEm/CreativeMarket/EVE Online False Positives

### DIFF
--- a/data.json
+++ b/data.json
@@ -153,7 +153,8 @@
     "urlMain": "https://coroflot.com/"
   },
   "CreativeMarket": {
-    "errorType": "status_code",
+    "errorType": "response_url",
+    "errorUrl": "https://www.creativemarket.com/",
     "url": "https://creativemarket.com/{}",
     "urlMain": "https://creativemarket.com/"
   },
@@ -197,9 +198,9 @@
     "urlMain": "https://dribbble.com/"
   },
   "EVE Online": {
-    "errorMsg": "No results found with your search...",
-    "errorType": "message",
-    "url": "https://evewho.com/search/{}",
+    "errorType": "response_url",
+    "errorUrl": "https://eveonline.com",
+    "url": "https://evewho.com/pilot/{}/",
     "urlMain": "https://eveonline.com"
   },
   "Ebay": {
@@ -220,7 +221,8 @@
     "urlMain": "https://www.etsy.com/"
   },
   "EyeEm": {
-    "errorType": "status_code",
+    "errorType": "response_url",
+    "errorUrl": "https://www.eyeem.com/",
     "url": "https://www.eyeem.com/u/{}",
     "urlMain": "https://www.eyeem.com/"
   },

--- a/tests/all.py
+++ b/tests/all.py
@@ -111,7 +111,8 @@ class SherlockSiteCoverageTests(SherlockBaseTest):
 
         self.username_check(['noonewouldeverusethis7'],
                             ["Pinterest", "iMGSRC.RU", "Pastebin",
-                             "WordPress", "devRant", "ImageShack", "MeetMe"
+                             "WordPress", "devRant", "ImageShack", "MeetMe",
+                             "EyeEm", "CreativeMarket", "EVE Online"
                             ],
                             exist_check=False
                            )
@@ -134,7 +135,8 @@ class SherlockSiteCoverageTests(SherlockBaseTest):
 
         self.username_check(['blue'],
                             ["Pinterest", "iMGSRC.RU", "Pastebin",
-                             "WordPress", "devRant", "ImageShack", "MeetMe"
+                             "WordPress", "devRant", "ImageShack", "MeetMe",
+                             "EyeEm", "CreativeMarket", "EVE Online"
                             ],
                             exist_check=True
                            )


### PR DESCRIPTION
This is the fix for #140.

Change EyeEm/CreativeMarket/EVE Online detection method to use the newly refurbished "response_url" detection method.