### PR TITLE
Fix issue with site name and url

### DIFF
--- a/site_list.py
+++ b/site_list.py
@@ -47,7 +47,7 @@ with open("sites.md", "w") as site_file:
 			th = threading.Thread(target=get_rank, args=(url_main, data.get(social_network)))
 		else:
 			th = None
-		pool.append((url_main, url_main, th))
+		pool.append((social_network, url_main, th))
 		if args.rank:
 			th.start()
 


### PR DESCRIPTION
In `site_list.py`, `url_main` is present in the tuple appended to `pool` twice - `(url_main, url_main, th)` which would yield incorrect results. It should be `(social_network, url_main, th)`.